### PR TITLE
use global class name to style geoCoder component

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -35,6 +35,7 @@
 				zoom: 10
 			});
 		}}
+		class="geoCodeControl"
 	/>
 
     <!-- <Control position="top-right"/> -->
@@ -77,5 +78,9 @@
 <style>
 	:global(.map) {
 		height: 500px;
+	}
+
+	:global(.geoCodeControl) {
+		margin: 10px 15px;
 	}
 </style>


### PR DESCRIPTION
Looks like you sort of solved it by moving other controls to the right, but if you wan to customize the css on this component this gives you an idea how to do it at least. 